### PR TITLE
Support for multiple (at) characters

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -28,6 +28,14 @@ export function getRange() {
   }
 }
 
+export function getAtAndIndex(text, ats) {
+  return ats.map((at) => {
+    return { at, index: text.lastIndexOf(at) }
+  }).reduce((a, b) => {
+    return a.index > b.index ? a : b
+  })
+}
+
 /* eslint-disable */
 // http://stackoverflow.com/questions/26747240/plain-javascript-replication-to-offset-and-position
 export function getOffset(element, target) {


### PR DESCRIPTION
The idea behind this is that you can specify multiple `ats`. The one that's matched will be passed to your filter function so you can just filter the members based on that.

This should work as normal when you pass `at` (no breaking changes).