### PR TITLE
close textarea panel if empty of text

### DIFF
--- a/src/At.vue
+++ b/src/At.vue
@@ -231,7 +231,7 @@ export default {
           }
           return
         }
-        if (e.keyCode === 13) { // enter
+        if (e.keyCode === 13 || e.keyCode === 9) { // enter or tab
           this.insertItem()
           e.preventDefault()
           e.stopPropagation()

--- a/src/AtTextarea.vue
+++ b/src/AtTextarea.vue
@@ -93,6 +93,8 @@ export default {
             this.closePanel()
           }
         }
+      } else {
+        this.closePanel()
       }
     },
 


### PR DESCRIPTION
This removes the panel if there is no text for a textarea div.

As you can see in the example page at https://fritx.github.io/vue-at/#/en/vmodel if you have the panel open, then select all the text with the mouse and then hit delete the panel closes for the contenteditable example, but not the textarea example.