### PR TITLE
At panel can open with results triggered externally from the node it is wrapping

### DIFF
--- a/src/At.vue
+++ b/src/At.vue
@@ -286,17 +286,17 @@ export default {
 
       const range = getPrecedingRange()
 
-      if (keep) {
-        // exit the function if the range is not inside this.$el
-        let container = range.commonAncestorContainer;
-        while (container) {
-          if (container === this.$el) break;
-          container = container.parentElement;
-          if (!container) return;
-        }
-      }
-
       if (range) {
+        if (keep) {
+          // exit the function if the range is not inside this.$el
+          let container = range.commonAncestorContainer;
+          while (container) {
+            if (container === this.$el) break;
+            container = container.parentElement;
+            if (!container) return;
+          }
+        }
+        
         const { atItems, avoidEmail, allowSpaces, showUnique } = this
 
         let show = true

--- a/src/At.vue
+++ b/src/At.vue
@@ -285,6 +285,17 @@ export default {
       this.$emit('input', el.innerHTML)
 
       const range = getPrecedingRange()
+
+      if (keep) {
+        // exit the function if the range is not inside this.$el
+        let container = range.commonAncestorContainer;
+        while (container) {
+          if (container === this.$el) break;
+          container = container.parentElement;
+          if (!container) return;
+        }
+      }
+
       if (range) {
         const { atItems, avoidEmail, allowSpaces, showUnique } = this
 


### PR DESCRIPTION
In rare cases it's possible to trigger `handleInput` via the watch of `members` from a node external to the one wrapped by the `At` instance.

The happened in the following scenario:

- We have a rendered "mention" in a message thread
- Clicking it does several things one of which results in triggering an update to a data item which happens to also be in the `At` `members` pool.
- The watch of `members` kicks in
- the `range` in `handleInput` get created but its `commonAncestorContainer` is the text node belonging to the link in the message thread, completely external to the `At` instance
- Because the text value of the link includes `@` ie. it is a display of a mention the mention detection based on the range kicks in
- This results in the `At` instance matching valid results and displaying the panel even tho no input was actually entered in the input wrapped by the `At`
- in addition to this if you click an item in the mentions panel it will insert into the external link node (this somewhat is unimportant because all that need to be fixed it the root cause)

To resolve this issue the following logic was added

- After the range is created, recursively walk the node tree from `range.commonAncestorContainer` to check it is inside of the `At` instances `this.$el` if it isn't exit the rest of the `handleInput` function
- This only occurs if `keep` is true which is currently only set in the watch as thats the only time it needs to happen 

In theory this could happen at any time an update to members occurs and the range gets creating from a node external to the one the instance is wrapping and happens to have a sting containing a mention like pattern.